### PR TITLE
synchronize update about widget isActive boolean.

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,11 +1,13 @@
 const {
-  app, BrowserWindow, Menu, Tray,
+  app, BrowserWindow, remote, Menu, Tray,
 } = require('electron');
 const path = require('path');
 const url = require('url');
+const fs = require('fs');
 const { ipcMain } = require('electron');
 const WidgetManager = require('./src/WidgetManager');
 
+let informationBeforeQuit;
 let setting_win;
 const widgetManager = new WidgetManager({
   icon: path.join(__dirname, 'resource', 'icon.png'),
@@ -103,6 +105,20 @@ if (process.platform === 'darwin') {
 app.on('ready', init);
 
 app.on('window-all-closed', () => {
+});
+
+app.on('before-quit', () => {
+  informationBeforeQuit = JSON.stringify(widgetManager.widgetStore.getAll());
+});
+
+app.on('quit', () => {
+  const configName = 'widgets';
+  const userDataPath = (app || remote.app).getPath('userData');
+  const savedPath = path.join(userDataPath, `${configName}.json`);
+
+  fs.writeFile(savedPath, informationBeforeQuit, (err) => {
+    if (err) throw new Error(err);
+  });
 });
 
 app.on('activate', () => {

--- a/src/WidgetManager.js
+++ b/src/WidgetManager.js
@@ -134,6 +134,15 @@ class WidgetManager {
       delete this.windows[opt.id];
     });
 
+    win.on('close', () => {
+      const _opt = this.widgetStore.get(opt.id);
+      _opt.isActive = false;
+
+      this.widgetStore.set(_opt.id, _opt);
+      win.webContents.send('widget-info', _opt);
+      this.sendToSettingWindow(this.widgetStore.data);
+    });
+
     win.on('move', (() => {
       const position = win.getPosition();
       const _opt = this.widgetStore.get(opt.id);


### PR DESCRIPTION
I have issue isActive toggle to false when main process shut down.
So I don't add event that set false value of isActive.

I use 'before-quit', 'quit' event in app.on.
1. I save current information when call 'before-quit' event.
2. browserWindow.close event is called then isActive values are changed to false.
3. I save information before changed isActive in widget.json file.

fix about issue #47