### PR TITLE
add default menu in main process

### DIFF
--- a/main.js
+++ b/main.js
@@ -6,6 +6,7 @@ const url = require('url');
 const fs = require('fs');
 const { ipcMain } = require('electron');
 const WidgetManager = require('./src/WidgetManager');
+const createMenu = require('./src/createMenu');
 
 let informationBeforeQuit;
 let setting_win;
@@ -68,6 +69,7 @@ function createTray(contextMenuTemplate) {
 function init() {
   widgetManager.onUpdateTray(createTray);
   widgetManager.openAllWindow();
+  createMenu();
 
   ipcMain.on('WIDGET_MANAGE', (event, arg) => {
     if (arg.operation === 'CREATE') {

--- a/src/createMenu.js
+++ b/src/createMenu.js
@@ -1,0 +1,85 @@
+const { app, Menu } = require('electron');
+
+// reference by https://electronjs.org/docs/api/menu#examples
+function createMenu() {
+  const template = [
+    {
+      label: 'Edit',
+      submenu: [
+        { role: 'undo' },
+        { role: 'redo' },
+        { type: 'separator' },
+        { role: 'cut' },
+        { role: 'copy' },
+        { role: 'paste' },
+        { role: 'pasteandmatchstyle' },
+        { role: 'delete' },
+        { role: 'selectall' },
+      ],
+    },
+    {
+      label: 'View',
+      submenu: [
+        { role: 'reload' },
+        { role: 'forcereload' },
+        { role: 'toggledevtools' },
+        { type: 'separator' },
+        { role: 'resetzoom' },
+        { role: 'zoomin' },
+        { role: 'zoomout' },
+        { type: 'separator' },
+        { role: 'togglefullscreen' },
+      ],
+    },
+    {
+      role: 'window',
+      submenu: [
+        { role: 'minimize' },
+        { role: 'close' },
+      ],
+    },
+  ];
+
+  if (process.platform === 'darwin') {
+    template.unshift({
+      label: app.getName(),
+      submenu: [
+        { role: 'about' },
+        { type: 'separator' },
+        { role: 'services', submenu: [] },
+        { type: 'separator' },
+        { role: 'hide' },
+        { role: 'hideothers' },
+        { role: 'unhide' },
+        { type: 'separator' },
+        { role: 'quit' },
+      ],
+    });
+
+    // Edit menu
+    template[1].submenu.push(
+      { type: 'separator' },
+      {
+        label: 'Speech',
+        submenu: [
+          { role: 'startspeaking' },
+          { role: 'stopspeaking' },
+        ],
+      },
+    );
+
+    // Window menu
+    template[3].submenu = [
+      { role: 'close' },
+      { role: 'minimize' },
+      { role: 'zoom' },
+      { type: 'separator' },
+      { role: 'front' },
+    ];
+  }
+
+  const menu = Menu.buildFromTemplate(template);
+  Menu.setApplicationMenu(menu);
+}
+
+module.exports = createMenu();


### PR DESCRIPTION
default key event(like copy and past or select all) is not call when build environment.
So add default menu.
refer https://electronjs.org/docs/api/menu#examples