### PR TITLE
change method `fs.writeFile()` to `fs.writeFileSync()`

### DIFF
--- a/main.js
+++ b/main.js
@@ -188,25 +188,6 @@ if (process.platform === 'darwin') {
   app.dock.hide();
 }
 
-// save file when close main process
-// if data is not save correctly, call saveData function recursive
-function saveData(info) {
-  const configName = 'widgets';
-  const userDataPath = (app || remote.app).getPath('userData');
-  const savedPath = path.join(userDataPath, `${configName}.json`);
-
-  fs.writeFile(savedPath, info, (err) => {
-    if (err) throw new Error(err);
-  });
-
-  fs.readFile(savedPath, 'utf8', (err, data) => {
-    if (data !== info) {
-      console.log('save'); // eslint-disable-line no-console
-      saveData(info);
-    }
-  });
-}
-
 app.on('ready', init);
 
 app.on('window-all-closed', () => {
@@ -217,7 +198,11 @@ app.on('before-quit', () => {
 });
 
 app.on('quit', () => {
-  saveData(informationBeforeQuit);
+  const configName = 'widgets';
+  const userDataPath = (app || remote.app).getPath('userData');
+  const savedPath = path.join(userDataPath, `${configName}.json`);
+
+  fs.writeFileSync(savedPath, informationBeforeQuit);
 });
 
 app.on('activate', () => {

--- a/src/Store.js
+++ b/src/Store.js
@@ -46,9 +46,7 @@ class Store {
   save() {
     if (!fs.existsSync(this.userDataPath)) fs.mkdirSync(this.userDataPath);
 
-    fs.writeFile(this.path, JSON.stringify(this.data), (err) => {
-      if (err) throw new Error(err);
-    });
+    fs.writeFileSync(this.path, JSON.stringify(this.data));
   }
 
   parseDataFile(defaults) {


### PR DESCRIPTION
fix about #68.
when I use node File System, I use method fs.writeFile() that has asynchronous feature.

issue is occurred fs.writeFile of main process and renderer process when close app.
fs.writeFile has asynchronous feature, No one know order of fs.writeFilebecause of asynchronous feature. so widget.json that saved in user computer doesn't have correct data.

I will change fs.writerFile() to fs.writeFileSync for synchronous feature.