### PR TITLE
Fix web widget title bar style for click event

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -22,7 +22,8 @@
     "import/no-named-as-default": 0,
     "import/no-duplicates": 0,
     "import/no-named-as-default-member": 0,
-    "jsx-a11y/anchor-is-valid": 0
+    "jsx-a11y/anchor-is-valid": 0,
+    "linebreak-style": ["error", "windows"]
   },
   "globals": {
     "__DEV__": false,

--- a/app/page/webview/components/WebWidget/components/WebWidgetHeader/WebWidgetHeaer.scss
+++ b/app/page/webview/components/WebWidget/components/WebWidgetHeader/WebWidgetHeaer.scss
@@ -1,5 +1,6 @@
 .WebWidgetHeader__front-btn-set {
   display: flex;
+  -webkit-app-region: no-drag;
   align-items: center;
 }
 
@@ -19,6 +20,7 @@
   float: right;
   display: flex;
   align-items: center;
+  -webkit-app-region: no-drag;
   position: relative;
 }
 


### PR DESCRIPTION
## Type
Bug Fix

## Content
I found title bar button is not actived in window environment
Because Button's parenet has `-webkit-app-region: drag` style code.
So Add Button style that `-webkit-app-region: no-drag`.