### PR TITLE
Add case about save widget setting.

### DIFF
--- a/app/main/controllers/__tests__/widget.spec.js
+++ b/app/main/controllers/__tests__/widget.spec.js
@@ -4,7 +4,10 @@ import * as TYPES from 'actions/constant/actionTypes';
 import storeMock from 'store/storeMain';
 import { openBrowserWindow } from 'actions/window';
 import * as utils from 'main/utils/widget/makeWidget';
+import saveData from 'main/utils/disk/saveData';
 import widgetController from '../widget';
+
+jest.mock('main/utils/disk/saveData');
 
 describe('test widgetController', () => {
   beforeEach(() => {
@@ -41,6 +44,7 @@ describe('test widgetController', () => {
         mockBrowserWindow,
       ),
     );
+    expect(saveData).toHaveBeenCalledTimes(1);
   });
 
   describe('should handle TYPES.WIDGET_OPEN', () => {

--- a/app/main/controllers/widget.js
+++ b/app/main/controllers/widget.js
@@ -13,6 +13,7 @@ import { isUrlCheckFetchSelector } from 'store/reducers/share/status/selectors';
 import { modalOpen } from 'actions/modal';
 import * as sharedId from 'store/reducers/share/identification/selectors';
 import * as identificationSelector from 'store/reducers/personal/identification/selectors';
+import saveData from 'main/utils/disk/saveData';
 
 const widgetController = (action, prev) => {
   const { type } = action;
@@ -22,6 +23,7 @@ const widgetController = (action, prev) => {
       const widgetWin = makeWidget(id, undefined, true);
 
       store.dispatch(openBrowserWindow(id, widgetWin));
+      saveData();
       break;
     }
     case TYPES.WIDGET_OPEN: {
@@ -39,7 +41,6 @@ const widgetController = (action, prev) => {
 
         store.dispatch(openBrowserWindow(id, widgetWin));
       }
-
       break;
     }
     case TYPES.WIDGET_CLOSE:
@@ -51,7 +52,6 @@ const widgetController = (action, prev) => {
       if (widget) {
         widget.close();
       }
-
       break;
     }
     case TYPES.WIDGET_UPDATE_INFO: {

--- a/app/main/utils/init.js
+++ b/app/main/utils/init.js
@@ -11,8 +11,12 @@ import openAllWidgetStatusOpen from 'main/utils/window/openAllWidgetStatusOpen';
 import store from 'store/storeMain';
 import subscribeActionMain from 'store/utils/subscribeActionMain';
 import { hotKeySearchWindowSelector } from 'store/reducers/share/config/selectors';
+import saveData from 'main/utils/disk/saveData';
 import TrayMenuBar from 'main/utils/menu/trayMenuBar';
 import { setInitialStore } from 'actions/setting';
+
+// save data about setting every 5 minutes.
+const SAVE_SETTING_INTERVAL = 300000;
 
 function init() {
   autoLaunch();
@@ -21,6 +25,7 @@ function init() {
   handlingSearchHotKey(hotKeySearchWindowSelector(store.getState()));
   openAllWidgetStatusOpen();
   autoUpdater.checkForUpdatesAndNotify();
+  setInterval(saveData, SAVE_SETTING_INTERVAL);
 
   app.on('activate', (e, isOpenWindow) => {
     if (!isOpenWindow) {


### PR DESCRIPTION

## Purpose
Fix for #157 issue 

## Done
- save setting every 5 minutes.
- save setting when add new widget.

## Notice
Now, When make widget or When every 5 minutes, update widget setting and preserve data if you restart window.

But It exist a limit. When update widget information(like `always on top` or `position of widget in desktop`) or delete widget, It is not updated instantly. It will update When five minutes have elapsed(Periodic save) or when quit the app normally.

If you feel that this limit is inconvenient, Please leave comment. I will spend more time fixing this.